### PR TITLE
Fix a pydantic crash while enrolling

### DIFF
--- a/octoprint_mfa_totp/__init__.py
+++ b/octoprint_mfa_totp/__init__.py
@@ -18,7 +18,7 @@ VALID_WINDOW = 1  # delay of one tick is ok
 class MfaTotpUserSettings(BaseModel):
     created: int
     secret: str
-    last_used: str = None
+    last_used: str | None = None
     active: bool = False
 
 


### PR DESCRIPTION
In my setup, OctoPrint 1.11.0.dev287 (latest maintanance branch), Windows and Python 3.12.7, OctoPrint-MfaTotp crashes when clicking the Enroll button, with the following stacktrace:

```
octoprint.server.api - ERROR - Error while executing SimpleApiPlugin mfa_totp
Traceback (most recent call last):
  File "OctoPrint\src\octoprint\server\api\__init__.py", line 157, in pluginCommand
    response = api_plugin.on_api_command(command, data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "OctoPrint\src\octoprint\util\__init__.py", line 1683, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "OctoPrint-MfaTotp\octoprint_mfa_totp\__init__.py", line 160, in on_api_command
    key, uri = self._enroll_user(userid)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "OctoPrint-MfaTotp\octoprint_mfa_totp\__init__.py", line 85, in _enroll_user
    self._data.users[userid] = MfaTotpUserSettings(
                               ^^^^^^^^^^^^^^^^^^^^
  File "OctoPrint\venv\Lib\site-packages\pydantic\main.py", line 212, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for MfaTotpUserSettings
last_used
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.9/v/string_type
```

I believe the error is due to the `MfaTotpUserSettings.last_used` field, which is declared as `str` but initialized to `None`.
This PR changes the field declaration to `str|None`. I'm not sure if this is the best change based on the context of the code, but at least it fixes the crash.